### PR TITLE
Update pod dependency for TextRecognition

### DIFF
--- a/text-recognition/RNMLKitTextRecognition.podspec
+++ b/text-recognition/RNMLKitTextRecognition.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "GoogleMLKit/TextRecognition", "2.2.0"
+  s.dependency "GoogleMLKit/TextRecognition", "2.3.0"
 end
 


### PR DESCRIPTION
Ensure the same GoogleMLKit version when using multiple packages within the same project. FaceDetection was using 2.3.0 and TextRecognition 2.2.0 which had incompatible GoogleMLKit versions.