### PR TITLE
Upgrade GoogleMLKit

### DIFF
--- a/text-recognition/RNMLKitTextRecognition.podspec
+++ b/text-recognition/RNMLKitTextRecognition.podspec
@@ -22,14 +22,14 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   # To recognize Latin script
-  s.dependency 'GoogleMLKit/TextRecognition', '6.0.0'
+  s.dependency 'GoogleMLKit/TextRecognition', '8.0.0'
   # To recognize Chinese script
-  s.dependency 'GoogleMLKit/TextRecognitionChinese', '6.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionChinese', '8.0.0'
   # To recognize Devanagari script
-  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '6.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '8.0.0'
   # To recognize Japanese script
-  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '6.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '8.0.0'
   # To recognize Korean script
-  s.dependency 'GoogleMLKit/TextRecognitionKorean', '6.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionKorean', '8.0.0'
 end
 

--- a/text-recognition/android/build.gradle
+++ b/text-recognition/android/build.gradle
@@ -62,13 +62,13 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     // To recognize Latin script
-    implementation 'com.google.mlkit:text-recognition:16.0.0'
+    implementation 'com.google.mlkit:text-recognition:16.0.1'
     // To recognize Chinese script
-    implementation 'com.google.mlkit:text-recognition-chinese:16.0.0'
+    implementation 'com.google.mlkit:text-recognition-chinese:16.0.1'
     // To recognize Devanagari script
-    implementation 'com.google.mlkit:text-recognition-devanagari:16.0.0'
+    implementation 'com.google.mlkit:text-recognition-devanagari:16.0.1'
     // To recognize Japanese script
-    implementation 'com.google.mlkit:text-recognition-japanese:16.0.0'
+    implementation 'com.google.mlkit:text-recognition-japanese:16.0.1'
     // To recognize Korean script
-    implementation 'com.google.mlkit:text-recognition-korean:16.0.0'
+    implementation 'com.google.mlkit:text-recognition-korean:16.0.1'
 }


### PR DESCRIPTION
https://github.com/a7medev/react-native-ml-kit/issues/65

This PR upgrades the Google ML Kit dependency used in the `text-recognition` module to the latest available version.