### PR TITLE
feat: add rotation degree and confidence score

### DIFF
--- a/example/src/text-recognition/TextMap.tsx
+++ b/example/src/text-recognition/TextMap.tsx
@@ -33,7 +33,14 @@ const TextMap = ({
         <React.Fragment key={blockId}>
           {showBlocks && (
             <TouchableOpacity
-              onPress={() => Alert.alert(block.text)}
+              onPress={() =>
+                Alert.alert(
+                  block.text,
+                  `Confidence Score and Rotation Degree of 1st line:
+                   \nConfidence Score: ${getConfidenceScore(block)}
+                   \nRotation Degree: ${getRotationDegree(block)}`,
+                )
+              }
               style={[styles.text, scaledFrame(block.frame)]}
             />
           )}
@@ -58,6 +65,14 @@ const TextMap = ({
       ))}
     </>
   );
+
+  function getRotationDegree(block: TextBlock) {
+    return block.lines[0]?.rotationDegree?.toFixed(2) ?? 0;
+  }
+
+  function getConfidenceScore(block: TextBlock) {
+    return block.lines[0]?.confidenceScore?.toFixed(2) ?? 0;
+  }
 };
 
 const styles = StyleSheet.create({

--- a/example/src/text-recognition/TextMap.tsx
+++ b/example/src/text-recognition/TextMap.tsx
@@ -36,9 +36,9 @@ const TextMap = ({
               onPress={() =>
                 Alert.alert(
                   block.text,
-                  `Confidence Score and Rotation Degree of 1st line:
-                   \nConfidence Score: ${getConfidenceScore(block)}
-                   \nRotation Degree: ${getRotationDegree(block)}`,
+                  "Confidence score and rotation degree of 1st line\n\n" +
+                  `Confidence score: ${getConfidenceScore(block)}\n\n` +
+                  `Rotation degree: ${getRotationDegree(block)}`,
                 )
               }
               style={[styles.text, scaledFrame(block.frame)]}

--- a/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
+++ b/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
@@ -101,9 +101,9 @@ public class TextRecognitionModule extends ReactContextBaseJavaModule {
 		}
         map.putArray("recognizedLanguages", langToMap(line.getRecognizedLanguage()));
 
-        map.putDouble("confidenceScore", (double) line.getConfidence());
+        map.putDouble("confidenceScore", line.getConfidence());
 
-        map.putDouble("rotationDegree", (double) line.getAngle());
+        map.putDouble("rotationDegree", line.getAngle());
 
         WritableArray elements = Arguments.createArray();
         for (Text.Element element : line.getElements()) {

--- a/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
+++ b/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
@@ -89,6 +89,22 @@ public class TextRecognitionModule extends ReactContextBaseJavaModule {
         return array;
     }
 
+    private ReadableArray rotationToMap(float rotation) {
+      WritableArray array = Arguments.createArray();
+      WritableMap map = Arguments.createMap();
+      map.putDouble("rotationDegree", (double) rotation);
+      array.pushMap(map);
+      return array;
+    }
+
+    private ReadableArray confidenceToMap(float confidence) {
+      WritableArray array = Arguments.createArray();
+      WritableMap map = Arguments.createMap();
+      map.putDouble("confidenceScore", (double) confidence);
+      array.pushMap(map);
+      return array;
+    }
+
     private ReadableMap lineToMap(Text.Line line) {
         WritableMap map = Arguments.createMap();
 
@@ -100,6 +116,10 @@ public class TextRecognitionModule extends ReactContextBaseJavaModule {
 			map.putArray("cornerPoints", cornerPointsToMap(line.getCornerPoints()));
 		}
         map.putArray("recognizedLanguages", langToMap(line.getRecognizedLanguage()));
+
+        map.putArray("confidenceScore", confidenceToMap(line.getConfidence()));
+
+        map.putArray("rotationAngle", rotationToMap(line.getAngle()));
 
         WritableArray elements = Arguments.createArray();
         for (Text.Element element : line.getElements()) {

--- a/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
+++ b/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
@@ -89,22 +89,6 @@ public class TextRecognitionModule extends ReactContextBaseJavaModule {
         return array;
     }
 
-    private ReadableArray rotationToMap(float rotation) {
-      WritableArray array = Arguments.createArray();
-      WritableMap map = Arguments.createMap();
-      map.putDouble("rotationDegree", (double) rotation);
-      array.pushMap(map);
-      return array;
-    }
-
-    private ReadableArray confidenceToMap(float confidence) {
-      WritableArray array = Arguments.createArray();
-      WritableMap map = Arguments.createMap();
-      map.putDouble("confidenceScore", (double) confidence);
-      array.pushMap(map);
-      return array;
-    }
-
     private ReadableMap lineToMap(Text.Line line) {
         WritableMap map = Arguments.createMap();
 
@@ -117,9 +101,9 @@ public class TextRecognitionModule extends ReactContextBaseJavaModule {
 		}
         map.putArray("recognizedLanguages", langToMap(line.getRecognizedLanguage()));
 
-        map.putArray("confidenceScore", confidenceToMap(line.getConfidence()));
+        map.putDouble("confidenceScore", (double) line.getConfidence());
 
-        map.putArray("rotationAngle", rotationToMap(line.getAngle()));
+        map.putDouble("rotationDegree", (double) line.getAngle());
 
         WritableArray elements = Arguments.createArray();
         for (Text.Element element : line.getElements()) {

--- a/text-recognition/index.ts
+++ b/text-recognition/index.ts
@@ -45,7 +45,7 @@ export interface TextLine {
    * @platform Android
    */
   confidenceScore?: number;
-    /**
+  /**
    * Angle (in degrees, clockwise is positive, range is [-180, 180]) of the rotation of the recognized line.
    *
    * @platform Android

--- a/text-recognition/index.ts
+++ b/text-recognition/index.ts
@@ -39,10 +39,16 @@ export interface TextLine {
   elements: TextElement[];
   /** Languages recognized in the line */
   recognizedLanguages: Language[];
-  /** Confidence score of the line */
-  confidenceScore: number;
-  /** Rotation degree of the line */
-  rotationDegree: number;
+  /** Confidence score of the line (Android only)
+   *
+   * @platform Android
+   * */
+  confidenceScore?: number;
+  /** Rotation degree of the line (Android only)
+   *
+   * @platform Android
+   * */
+  rotationDegree?: number;
 }
 
 export interface TextBlock {

--- a/text-recognition/index.ts
+++ b/text-recognition/index.ts
@@ -39,15 +39,17 @@ export interface TextLine {
   elements: TextElement[];
   /** Languages recognized in the line */
   recognizedLanguages: Language[];
-  /** Confidence score of the line (Android only)
+  /**
+   * Confidence score of the line.
    *
    * @platform Android
-   * */
+   */
   confidenceScore?: number;
-  /** Rotation degree of the line (Android only)
+    /**
+   * Angle (in degrees, clockwise is positive, range is [-180, 180]) of the rotation of the recognized line.
    *
    * @platform Android
-   * */
+   */
   rotationDegree?: number;
 }
 

--- a/text-recognition/index.ts
+++ b/text-recognition/index.ts
@@ -39,6 +39,10 @@ export interface TextLine {
   elements: TextElement[];
   /** Languages recognized in the line */
   recognizedLanguages: Language[];
+  /** Confidence score of the line */
+  confidenceScore: number;
+  /** Rotation degree of the line */
+  rotationDegree: number;
 }
 
 export interface TextBlock {


### PR DESCRIPTION
Resolves #40 by adding `confidenceScore` and `rotationDegree`. Unfortunately those values are supported on **android** only but not **ios**.

Fixes #40.